### PR TITLE
Add support for ignoring undefined variables by pattern.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,8 @@ then in your ~/.eslintrc:
 
 `jsx/no-undef` also accepts a `varsIgnorePattern` which can be used to ignore certain undefined patterns (e.g. when using custom web elements).
 
+`jsx/no-undef` also accepts a `ignoreAttributes` which can be used disregard linting of attributes (which incorrectly flags boolean attributes as undefined).
+
 All those rules are defined by default though so you can leave out the ones you agree with.
 
 ## Thanks

--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,8 @@ then in your ~/.eslintrc:
 }
 ```
 
+`jsx/no-undef` also accepts a `varsIgnorePattern` which can be used to ignore certain undefined patterns (e.g. when using custom web elements).
+
 All those rules are defined by default though so you can leave out the ones you agree with.
 
 ## Thanks

--- a/index.js
+++ b/index.js
@@ -71,6 +71,12 @@ const markUsedRule = context => {
  */
 
 const noUndefRule = context => {
+  const config = context.options[0] || {}
+  const ignored = config.varsIgnorePattern && new RegExp(config.varsIgnorePattern)
+  const isIgnored = ignored
+    ? name => ignored.test(name)
+    : () => false
+
   return {
     JSXOpeningElement(node) {
       var name = node.name
@@ -79,9 +85,9 @@ const noUndefRule = context => {
       const variables = variablesInScope(context)
       node.attributes.forEach(attr => {
         if (attr.type == 'JSXSpreadAttribute') return
-        if (attr.value == null) checkDefined(context, variables, attr.name)
+        if (attr.value == null && !isIgnored(attr.name.name)) checkDefined(context, variables, attr.name)
       })
-      if (!standardTags.has(name.name)) checkDefined(context, variables, name)
+      if (!standardTags.has(name.name) && !isIgnored(name.name)) checkDefined(context, variables, name)
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ const markUsedRule = context => {
 
 const noUndefRule = context => {
   const config = context.options[0] || {}
+  const ignoreAttributes = !!config.ignoreAttributes
   const ignored = config.varsIgnorePattern && new RegExp(config.varsIgnorePattern)
   const isIgnored = ignored
     ? name => ignored.test(name)
@@ -83,10 +84,13 @@ const noUndefRule = context => {
       if (name.type == 'JSXMemberExpression') name = name.object
       if (name.type == 'JSXNamespacedName') name = name.namespace
       const variables = variablesInScope(context)
-      node.attributes.forEach(attr => {
-        if (attr.type == 'JSXSpreadAttribute') return
-        if (attr.value == null && !isIgnored(attr.name.name)) checkDefined(context, variables, attr.name)
-      })
+
+      if (!ignoreAttributes) {
+        node.attributes.forEach(attr => {
+          if (attr.type == 'JSXSpreadAttribute') return
+          if (attr.value == null && !isIgnored(attr.name.name)) checkDefined(context, variables, attr.name)
+        })
+      }
       if (!standardTags.has(name.name) && !isIgnored(name.name)) checkDefined(context, variables, name)
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "jkroso/eslint-plugin-jsx",
   "keywords": ["eslint", "plugin", "jsx"],
   "scripts": {
-    "prepublish": "babel --presets node index.js > built.js"
+    "prepare": "babel --presets node index.js > built.js"
   },
   "author": "Jake Rosoman",
   "license": "MIT"


### PR DESCRIPTION
Fixes #2, but uses a pattern instead of the fixed `ignore` list mentioned there.